### PR TITLE
Delete CredentialsProvider

### DIFF
--- a/src/main/scala/org/embulk/input/DynamoDBUtil.scala
+++ b/src/main/scala/org/embulk/input/DynamoDBUtil.scala
@@ -30,9 +30,7 @@ object DynamoDBUtil {
   }
 
   def createClient(task: PluginTask): AmazonDynamoDBClient = {
-    val credentialsProvider: AWSCredentialsProvider = getCredentialsProvider(task)
     val client: AmazonDynamoDBClient = new AmazonDynamoDBClient(
-      credentialsProvider,
       new ClientConfiguration().withMaxConnections(10))
       .withRegion(Regions.fromName(task.getRegion))
 


### PR DESCRIPTION
AWS SDK DynamoDB Client is default use DefaultAWSCredentialsProviderChain.

http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html

So,if use IAM roles, 
### Before
Please Setting DynamoDB permission to EC2 Instance.
### next step example.
```
 embulk run ./dynamodb.yaml
```
It's OK.