### PR TITLE
[Do not merge] Use the real AWS Credentials

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,10 +22,29 @@ jobs:
       run: ./gradlew spotlessCheck
     - name: Set up DynamoDBLocal
       run:  docker run -d -p 8000:8000 amazon/dynamodb-local:latest -jar ./DynamoDBLocal.jar -inMemory -sharedDb -port 8000
+    - name: Set up AWS profile credentials
+      run: |
+        mkdir -p $HOME/.aws
+        cat <<EOS > $HOME/.aws/credentials
+        [test]
+        aws_access_key_id = ${AWS_ACCESS_KEY_ID}
+        aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
+        EOS
+        cat <<EOS > $HOME/.aws/config
+        [test]
+        region = us-east-1
+        EOS
+      env:
+        AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+        AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
     - name: Test with Gradle
       run: ./gradlew test
       env:
-        RUN_AWS_CREDENTIALS_TEST: false
+        EMBULK_DYNAMODB_TEST_PROFILE_NAME: test
+        AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+        AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+        EMBULK_DYNAMODB_TEST_ACCESS_KEY: ${{secrets.AWS_ACCESS_KEY_ID}}
+        EMBULK_DYNAMODB_TEST_SECRET_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
     - name: Archive test results
       if: always()
       uses: actions/upload-artifact@v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -45,6 +45,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
         EMBULK_DYNAMODB_TEST_ACCESS_KEY: ${{secrets.AWS_ACCESS_KEY_ID}}
         EMBULK_DYNAMODB_TEST_SECRET_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+        EMBULK_DYNAMODB_TEST_ASSUME_ROLE_ROLE_ARN: ${{secrets.EMBULK_DYNAMODB_TEST_ASSUME_ROLE_ROLE_ARN}}
     - name: Archive test results
       if: always()
       uses: actions/upload-artifact@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,29 @@ jobs:
       run: ./gradlew spotlessCheck
     - name: Set up DynamoDBLocal
       run:  docker run -d -p 8000:8000 amazon/dynamodb-local:latest -jar ./DynamoDBLocal.jar -inMemory -sharedDb -port 8000
+    - name: Set up AWS profile credentials
+      run: |
+        mkdir -p $HOME/.aws
+        cat <<EOS > $HOME/.aws/credentials
+        [test]
+        aws_access_key_id = ${AWS_ACCESS_KEY_ID}
+        aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
+        EOS
+        cat <<EOS > $HOME/.aws/config
+        [test]
+        region = us-east-1
+        EOS
+      env:
+        AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+        AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
     - name: Test with Gradle
       run: ./gradlew test
       env:
-        RUN_AWS_CREDENTIALS_TEST: false
+        EMBULK_DYNAMODB_TEST_PROFILE_NAME: test
+        AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+        AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+        EMBULK_DYNAMODB_TEST_ACCESS_KEY: ${{secrets.AWS_ACCESS_KEY_ID}}
+        EMBULK_DYNAMODB_TEST_SECRET_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
     - name: Archive test results
       if: always()
       uses: actions/upload-artifact@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
         EMBULK_DYNAMODB_TEST_ACCESS_KEY: ${{secrets.AWS_ACCESS_KEY_ID}}
         EMBULK_DYNAMODB_TEST_SECRET_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+        EMBULK_DYNAMODB_TEST_ASSUME_ROLE_ROLE_ARN: ${{secrets.EMBULK_DYNAMODB_TEST_ASSUME_ROLE_ROLE_ARN}}
     - name: Archive test results
       if: always()
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
* Follow up #13 
* Use the real aws credentials in tests about authentication.

@lulichn 
Could you set the below variables to Github secrets?
* `AWS_ACCESS_KEY_ID`
* `AWS_SECRET_ACCESS_KEY`
* `EMBULK_DYNAMODB_TEST_ASSUME_ROLE_ROLE_ARN`
    * This role must be an assumable role from the user identified by `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.

And the variables in CircleCI are not used, please remove the settings.
