### PR TITLE
Ship v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3.1 (2020-03-29)
+==================
+
+- [BugFix] [#23](https://github.com/lulichn/embulk-input-dynamodb/pull/23) Throw scala.MatchError when using "limit" option. (Fix [#21](https://github.com/lulichn/embulk-input-dynamodb/issues/21)) 
+- [Enhancement] [#23](https://github.com/lulichn/embulk-input-dynamodb/pull/23) Use embulk-core tests library instead of embulk-test.
+
 0.3.0 (2020-03-09)
 ==================
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ configurations {
     provided
 }
 
-version = "0.3.0"
+version = "0.3.1"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8


### PR DESCRIPTION
0.3.1 (2020-03-29)
==================

- [BugFix] [#23](https://github.com/lulichn/embulk-input-dynamodb/pull/23) Throw scala.MatchError when using "limit" option. (Fix [#21](https://github.com/lulichn/embulk-input-dynamodb/issues/21)) 
- [Enhancement] [#23](https://github.com/lulichn/embulk-input-dynamodb/pull/23) Use embulk-core tests library instead of embulk-test.