### PR TITLE
release: v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
+1.0.0 (2023-02-15)
+==================
+
+- [Breaking Change][#27](https://github.com/lulichn/embulk-input-dynamodb/pull/27) Upgrade embulk 0.9.23 -> 0.10.41 with removing deprecated features.
+    - Upgrade Gradle 6.1 -> 7.6
+    - Apply gradle-embulk-plugins
+    - Remove deprecated features
+    - Upgrade embulk 0.9.23 -> 0.10.41
+
 0.3.1 (2020-03-29)
 ==================
 
-- [BugFix] [#23](https://github.com/lulichn/embulk-input-dynamodb/pull/23) Throw scala.MatchError when using "limit" option. (Fix [#21](https://github.com/lulichn/embulk-input-dynamodb/issues/21)) 
+- [BugFix] [#23](https://github.com/lulichn/embulk-input-dynamodb/pull/23) Throw scala.MatchError when using "limit" option. (Fix [#21](https://github.com/lulichn/embulk-input-dynamodb/issues/21))
 - [Enhancement] [#23](https://github.com/lulichn/embulk-input-dynamodb/pull/23) Use embulk-core tests library instead of embulk-test.
 
 0.3.0 (2020-03-09)

--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,6 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    // note: The upper versions of embulk includes Guava Dependency removal,
-    //       so we need to specify the version of embulk to avoid some errors.
-    //       We may need to update the version of embulk in the future.
     def embulkVersion = "0.10.41"
     compileOnly "org.embulk:embulk-api:${embulkVersion}"
     compileOnly "org.embulk:embulk-spi:${embulkVersion}"


### PR DESCRIPTION
1.0.0 (2023-02-15)
==================

- [Breaking Change][#27](https://github.com/lulichn/embulk-input-dynamodb/pull/27) Upgrade embulk 0.9.23 -> 0.10.41 with removing deprecated features.
    - Upgrade Gradle 6.1 -> 7.6
    - Apply gradle-embulk-plugins
    - Remove deprecated features
    - Upgrade embulk 0.9.23 -> 0.10.41