### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+1.0.1 (2023-02-15)
+==================
+
+- [chore] [#30](https://github.com/lulichn/embulk-input-dynamodb/pull/30) Upgrade dependencies.
+
 1.0.0 (2023-02-15)
 ==================
 
-- [Breaking Change][#27](https://github.com/lulichn/embulk-input-dynamodb/pull/27) Upgrade embulk 0.9.23 -> 0.10.41 with removing deprecated features.
+- [Breaking Change] [#27](https://github.com/lulichn/embulk-input-dynamodb/pull/27) Upgrade embulk 0.9.23 -> 0.10.41 with removing deprecated features.
     - Upgrade Gradle 6.1 -> 7.6
     - Apply gradle-embulk-plugins
     - Remove deprecated features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 1.0.1 (2023-02-15)
 ==================
 
-- [chore] [#30](https://github.com/lulichn/embulk-input-dynamodb/pull/30) Upgrade dependencies.
+- [chore] [#29](https://github.com/lulichn/embulk-input-dynamodb/pull/29) Upgrade dependencies.
+    - Use `Exec.getPageBuilder` instead of `new PageBuilder`.
+    - Upgrade scala 2.13.1 -> 2.13.10
+    - Upgrade aws-sdk 1.11.171 -> 1.12.406
 
 1.0.0 (2023-02-15)
 ==================

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     def embulkVersion = "0.10.41"
     compileOnly "org.embulk:embulk-api:${embulkVersion}"
     compileOnly "org.embulk:embulk-spi:${embulkVersion}"
-    implementation "org.scala-lang:scala-library:2.13.1"
+    implementation "org.scala-lang:scala-library:2.13.10"
 
     implementation "org.embulk:embulk-util-config:0.3.2"
     implementation "org.embulk:embulk-util-json:0.1.1"

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ targetCompatibility = 1.8
 
 dependencies {
     def embulkVersion = "0.10.41"
+    def awsSdkVersion = "1.12.406"
     compileOnly "org.embulk:embulk-api:${embulkVersion}"
     compileOnly "org.embulk:embulk-spi:${embulkVersion}"
     implementation "org.scala-lang:scala-library:2.13.10"
@@ -37,8 +38,8 @@ dependencies {
     implementation "org.embulk:embulk-util-config:0.3.2"
     implementation "org.embulk:embulk-util-json:0.1.1"
     implementation "org.embulk:embulk-util-timestamp:0.2.1"
-    implementation "com.amazonaws:aws-java-sdk-dynamodb:1.11.711"
-    implementation "com.amazonaws:aws-java-sdk-sts:1.11.711"
+    implementation "com.amazonaws:aws-java-sdk-dynamodb:${awsSdkVersion}"
+    implementation "com.amazonaws:aws-java-sdk-sts:${awsSdkVersion}"
 
     testImplementation "junit:junit:4.+"
     testImplementation "org.embulk:embulk-junit4:${embulkVersion}"

--- a/src/main/scala/org/embulk/input/dynamodb/DynamodbInputPlugin.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/DynamodbInputPlugin.scala
@@ -38,7 +38,7 @@ class DynamodbInputPlugin extends InputPlugin {
       output: PageOutput
   ): TaskReport = {
     val task: PluginTask = PluginTask.load(taskSource)
-    val pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)
+    val pageBuilder = Exec.getPageBuilder(Exec.getBufferAllocator(), schema, output)
 
     Aws(task).withDynamodb { dynamodb =>
       DynamodbOperationProxy(task).run(

--- a/src/main/scala/org/embulk/input/dynamodb/DynamodbInputPlugin.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/DynamodbInputPlugin.scala
@@ -38,7 +38,8 @@ class DynamodbInputPlugin extends InputPlugin {
       output: PageOutput
   ): TaskReport = {
     val task: PluginTask = PluginTask.load(taskSource)
-    val pageBuilder = Exec.getPageBuilder(Exec.getBufferAllocator(), schema, output)
+    val pageBuilder =
+      Exec.getPageBuilder(Exec.getBufferAllocator(), schema, output)
 
     Aws(task).withDynamodb { dynamodb =>
       DynamodbOperationProxy(task).run(


### PR DESCRIPTION
- Use `Exec.getPageBuilder` instead of `new PageBuilder`.
- Upgrade scala 2.13.1 -> 2.13.10
- Upgrade aws-sdk 1.11.171 -> 1.12.406